### PR TITLE
Fail case for foreign composite key ordering.

### DIFF
--- a/.github/workflows/pull_request_workflow.yaml
+++ b/.github/workflows/pull_request_workflow.yaml
@@ -33,6 +33,10 @@ jobs:
         working-directory: ./main_branch/schema/
         run: ./establish.sh
 
+      - name: Check migration script is regenerated.
+        working-directory: ./main_branch/schema/
+        run: ./update_migration.sh
+
       # apply migration from current pull request
       - name: Run migration script from current pull request
         working-directory: ./schema/

--- a/schema/test_ddl.hcl
+++ b/schema/test_ddl.hcl
@@ -155,8 +155,8 @@ table "model_db_signal" {
     columns = [column.model_name, column.db_type, column.version, column.signal_name]
   }
   foreign_key "model_db_signal_model_name_db_type_version_fkey" {
-    columns     = [column.model_name, column.db_type, column.version]
-    ref_columns = [table.model_db.column.model_name, table.model_db.column.db_type, table.model_db.column.version]
+    columns     = [column.model_name, column.version, column.db_type]
+    ref_columns = [table.model_db.column.model_name, table.model_db.column.version, table.model_db.column.db_type]
     on_update   = NO_ACTION
     on_delete   = NO_ACTION
   }


### PR DESCRIPTION
It's odd situation, and it should not fail but,

When the foreign key name is like,

`model_db_signal_model_name_db_type_version_fkey`

but the column order is like,

```hcl
  foreign_key "model_db_signal_model_name_db_type_version_fkey" {
    columns     = [column.model_name, column.version, column.db_type]
    ref_columns = [table.model_db.column.model_name, table.model_db.column.version, table.model_db.column.db_type]
    on_update   = NO_ACTION
    on_delete   = NO_ACTION
  }

```

Then it is failing because foreign key name order is different with column order.

Failing means, even the DB is same, `atlas migrate diff` keep regenerate the migration script which does 1) delete existing foreign key, and 2) recreate foreign key with same composite key.

So, when u check this commit, it only changes the order of the key, but failing happens.